### PR TITLE
Introduces convenience macros for int32 and float64 for task options

### DIFF
--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -96,7 +96,7 @@ describe LuckyTask::Task do
     end
 
     it "sets int32 flags from args" do
-      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u 10,000","--zero=1_000"]).not_nil!
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u 10,000", "--zero=1_000"]).not_nil!
       task.zero.should eq 1_000
       task.uno.should eq 10_000
       expect_raises(Exception, /"nada" is an invalid value for uno/) do
@@ -105,7 +105,7 @@ describe LuckyTask::Task do
     end
 
     it "sets explicit negative/positive int32 flags from args" do
-      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u -10,000","--zero=+1_000"]).not_nil!
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u -10,000", "--zero=+1_000"]).not_nil!
       task.zero.should eq 1_000
       task.uno.should eq -10_000
     end
@@ -118,7 +118,7 @@ describe LuckyTask::Task do
     end
 
     it "sets float64 flags from args" do
-      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u 123_456.789","--zero=1_000"]).not_nil!
+      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u 123_456.789", "--zero=1_000"]).not_nil!
       task.zero.should eq 1_000.0
       task.uno.should eq 123_456.789
       task.pi.should eq 3.14
@@ -128,7 +128,7 @@ describe LuckyTask::Task do
     end
 
     it "sets explicit negative/positive float64 flags from args" do
-      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u -100","--zero=+505.1"]).not_nil!
+      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u -100", "--zero=+505.1"]).not_nil!
       task.zero.should eq 505.1
       task.uno.should eq -100.0
     end

--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -89,6 +89,21 @@ describe LuckyTask::Task do
       task.admin?.should eq true
     end
 
+    it "sets int32 flags that default to 0" do
+      task = TaskWithInt32Flags.new.print_help_or_call(args: [] of String).not_nil!
+      task.zero.should eq 0
+      task.uno.should eq 1
+    end
+
+    it "sets int32 flags from args" do
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u 10,000","--zero=1_000"]).not_nil!
+      task.zero.should eq 1_000
+      task.uno.should eq 10_000
+      expect_raises(Exception, /"nada" is an invalid value for uno/) do
+        TaskWithInt32Flags.new.print_help_or_call(args: ["-u nada"])
+      end
+    end
+
     it "allows positional args that do not require a flag name" do
       task = TaskWithPositionalArgs.new.print_help_or_call(args: ["User", "name:String", "email:String"]).not_nil!
       task.model.should eq "User"

--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -96,7 +96,7 @@ describe LuckyTask::Task do
     end
 
     it "sets int32 flags from args" do
-      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u 10,000", "--zero=1_000"]).not_nil!
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u 10000", "--zero=1_000"]).not_nil!
       task.zero.should eq 1_000
       task.uno.should eq 10_000
       expect_raises(Exception, /"nada" is an invalid value for uno/) do
@@ -105,7 +105,7 @@ describe LuckyTask::Task do
     end
 
     it "sets explicit negative/positive int32 flags from args" do
-      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u -10,000", "--zero=+1_000"]).not_nil!
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u -10_000", "--zero=+1_000"]).not_nil!
       task.zero.should eq 1_000
       task.uno.should eq -10_000
     end

--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -104,6 +104,35 @@ describe LuckyTask::Task do
       end
     end
 
+    it "sets explicit negative/positive int32 flags from args" do
+      task = TaskWithInt32Flags.new.print_help_or_call(args: ["-u -10,000","--zero=+1_000"]).not_nil!
+      task.zero.should eq 1_000
+      task.uno.should eq -10_000
+    end
+
+    it "sets float64 flags that default to 0" do
+      task = TaskWithFloat64Flags.new.print_help_or_call(args: [] of String).not_nil!
+      task.zero.should eq 0.0
+      task.uno.should eq 1.0
+      task.pi.should eq 3.14
+    end
+
+    it "sets float64 flags from args" do
+      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u 123_456.789","--zero=1_000"]).not_nil!
+      task.zero.should eq 1_000.0
+      task.uno.should eq 123_456.789
+      task.pi.should eq 3.14
+      expect_raises(Exception, /"nada" is an invalid value for uno/) do
+        TaskWithFloat64Flags.new.print_help_or_call(args: ["-u nada"])
+      end
+    end
+
+    it "sets explicit negative/positive float64 flags from args" do
+      task = TaskWithFloat64Flags.new.print_help_or_call(args: ["-u -100","--zero=+505.1"]).not_nil!
+      task.zero.should eq 505.1
+      task.uno.should eq -100.0
+    end
+
     it "allows positional args that do not require a flag name" do
       task = TaskWithPositionalArgs.new.print_help_or_call(args: ["User", "name:String", "email:String"]).not_nil!
       task.model.should eq "User"

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -69,6 +69,18 @@ class TaskWithInt32Flags < LuckyTask::Task
   end
 end
 
+class TaskWithFloat64Flags < LuckyTask::Task
+  summary "This is a task with float64 flags"
+
+  float64 :zero, "going to zero in a hurry"
+  float64 :uno, description: "defaults to one", shortcut: "-u", default: 1
+  float64 :pi, description: "defaults to PI", shortcut: "-p", default: 3.14
+
+  def call
+    self
+  end
+end
+
 class TaskWithPositionalArgs < LuckyTask::Task
   summary "This is a task with positional args"
 

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -58,6 +58,17 @@ class TaskWithSwitchFlags < LuckyTask::Task
   end
 end
 
+class TaskWithInt32Flags < LuckyTask::Task
+  summary "This is a task with int32 flags"
+
+  int32 :zero, "going to zero in a hurry"
+  int32 :uno, description: "defaults to one", shortcut: "-u", default: 1
+
+  def call
+    self
+  end
+end
+
 class TaskWithPositionalArgs < LuckyTask::Task
   summary "This is a task with positional args"
 

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -212,7 +212,7 @@ abstract class LuckyTask::Task
         if value !~ /^[\+\-]?[0-9\_\,]+$/
           raise <<-ERROR
             #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
-            Examples: 1 or 1,000 or 10_000
+            Examples: 1 or 1,000 or 10_000 or -1
           ERROR
         end
         @{{ arg_name.id }} = value.gsub(/[\_\,]/, "").to_i32
@@ -248,8 +248,8 @@ abstract class LuckyTask::Task
         value = value.strip.gsub("_", "")
         if value !~ /^[+-]?([0-9]*[.])?[0-9]+$/
           raise <<-ERROR
-            #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
-            Examples: 1 or 1,000 or 10_000
+            #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Float64
+            Examples: 1 or 1.0 or 1_000.0 or -1.0
           ERROR
         end
         @{{ arg_name.id }} = value.to_f64

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -234,7 +234,7 @@ abstract class LuckyTask::Task
   # * `default` : Float64 - An optional default value (`0.0` is default when omittted)
   #
   # Example:
-  #      float64 :threshold, "(0.1, 3.14, etc.)", shortcut: "-t", default: 2.0
+  #      float64 :threshold, "(0.1, 3.14, -5.1, etc.)", shortcut: "-t", default: 2.0
   macro float64(arg_name, description, shortcut = nil, default = nil)
     {% PARSER_OPTS << arg_name %}
     @{{ arg_name.id }} : Float64 = {{ default || 0.0 }}

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -209,13 +209,13 @@ abstract class LuckyTask::Task
         {{ description }}
       ) do |value|
         value = value.strip
-        if value !~ /^[\+\-]?[0-9\_\,]+$/
+        if value !~ /^[\+\-]?[0-9\_]+$/
           raise <<-ERROR
             #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
-            Examples: 1 or 1,000 or 10_000 or -1
+            Examples: 1 or 1000 or 10_000 or -1
           ERROR
         end
-        @{{ arg_name.id }} = value.gsub(/[\_\,]/, "").to_i32
+        @{{ arg_name.id }} = value.gsub(/[\_]/, "").to_i32
       end
     end
 

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -200,7 +200,7 @@ abstract class LuckyTask::Task
   #      int32 :limit, "limit (1000, 10_000, etc.)", shortcut: "-l", default: 1_000
   macro int32(arg_name, description, shortcut = nil, default = nil)
     {% PARSER_OPTS << arg_name %}
-    @{{ arg_name.id }} : Int32 = {% if default.nil? %}0{% else %}{{ default.id }}{% end %}
+    @{{ arg_name.id }} : Int32 = {{ default || 0 }}
 
     def set_opt_for_{{ arg_name.id }}(unused_args : Array(String))
       option_parser.on(
@@ -237,7 +237,7 @@ abstract class LuckyTask::Task
   #      float64 :threshold, "(0.1, 3.14, etc.)", shortcut: "-t", default: 2.0
   macro float64(arg_name, description, shortcut = nil, default = nil)
     {% PARSER_OPTS << arg_name %}
-    @{{ arg_name.id }} : Float64 = {% if default.nil? %}0{% else %}{{ default.id }}{% end %}
+    @{{ arg_name.id }} : Float64 = {{ default || 0.0 }}
 
     def set_opt_for_{{ arg_name.id }}(unused_args : Array(String))
       option_parser.on(

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -209,17 +209,54 @@ abstract class LuckyTask::Task
         {{ description }}
       ) do |value|
         value = value.strip
-        if value !~ /^[0-9\_\,]+$/
+        if value !~ /^[\+\-]?[0-9\_\,]+$/
           raise <<-ERROR
             #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
             Examples: 1 or 1,000 or 10_000
           ERROR
         end
-        @{{ arg_name.id }} = value.gsub(/\_|\,/, "").to_i32
+        @{{ arg_name.id }} = value.gsub(/[\_\,]/, "").to_i32
       end
     end
 
     def {{ arg_name.id }} : Int32
+      @{{ arg_name.id }}
+    end
+  end
+
+  # Creates a method of `arg_name` where the return value is an Float64.
+  # If the flag `--arg_name` is passed, the result is the value passed, otherwise is set to
+  # the specified default, or `0.0` when not specified.
+  #
+  # * `arg_name` : String - The name of the argument
+  # * `description` : String - The help text description for this option
+  # * `shorcut` : String - An optional short flag (e.g. `-a`)
+  # * `default` : Float64 - An optional default value (`0.0` is default when omittted)
+  #
+  # Example:
+  #      float64 :threshold, "(0.1, 3.14, etc.)", shortcut: "-t", default: 2.0
+  macro float64(arg_name, description, shortcut = nil, default = nil)
+    {% PARSER_OPTS << arg_name %}
+    @{{ arg_name.id }} : Float64 = {% if default.nil? %}0{% else %}{{ default.id }}{% end %}
+
+    def set_opt_for_{{ arg_name.id }}(unused_args : Array(String))
+      option_parser.on(
+        {% if shortcut %}"{{ shortcut.id }} {{ arg_name.stringify.upcase.id }}",{% end %}
+        "--{{ arg_name.id.stringify.underscore.gsub(/_/, "-").id }}={{ arg_name.id.stringify.upcase.id }}",
+        {{ description }}
+      ) do |value|
+        value = value.strip.gsub("_", "")
+        if value !~ /^[+-]?([0-9]*[.])?[0-9]+$/
+          raise <<-ERROR
+            #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
+            Examples: 1 or 1,000 or 10_000
+          ERROR
+        end
+        @{{ arg_name.id }} = value.to_f64
+      end
+    end
+
+    def {{ arg_name.id }} : Float64
       @{{ arg_name.id }}
     end
   end

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -187,6 +187,43 @@ abstract class LuckyTask::Task
     end
   end
 
+  # Creates a method of `arg_name` where the return value is an Int32.
+  # If the flag `--arg_name` is passed, the result is the value passed, otherwise is set to
+  # the specified default, or `0` when not specified.
+  #
+  # * `arg_name` : String - The name of the argument
+  # * `description` : String - The help text description for this option
+  # * `shorcut` : String - An optional short flag (e.g. `-a`)
+  # * `default` : Int32 - An optional default value (`0` is default when omittted)
+  #
+  # Example:
+  #      int32 :limit, "limit (1000, 10_000, etc.)", shortcut: "-l", default: 1_000
+  macro int32(arg_name, description, shortcut = nil, default = nil)
+    {% PARSER_OPTS << arg_name %}
+    @{{ arg_name.id }} : Int32 = {% if default.nil? %}0{% else %}{{ default.id }}{% end %}
+
+    def set_opt_for_{{ arg_name.id }}(unused_args : Array(String))
+      option_parser.on(
+        {% if shortcut %}"{{ shortcut.id }} {{ arg_name.stringify.upcase.id }}",{% end %}
+        "--{{ arg_name.id.stringify.underscore.gsub(/_/, "-").id }}={{ arg_name.id.stringify.upcase.id }}",
+        {{ description }}
+      ) do |value|
+        value = value.strip
+        if value !~ /^[0-9\_\,]+$/
+          raise <<-ERROR
+            #{value.inspect} is an invalid value for {{ arg_name.id }}. It should be a valid Int32
+            Examples: 1 or 1,000 or 10_000
+          ERROR
+        end
+        @{{ arg_name.id }} = value.gsub(/\_|\,/, "").to_i32
+      end
+    end
+
+    def {{ arg_name.id }} : Int32
+      @{{ arg_name.id }}
+    end
+  end
+
   abstract def call
   abstract def summary
 end


### PR DESCRIPTION
Similar in concept to the `switch` macro for generating `Bool` options, `int32` and `float64` introduces convenience macros for defining options that are expected to result in `Int32` or `Float64` input values.

Example:
```crystal
class TaskWithInt32Flags < LuckyTask::Task
  summary "This is a task with int32 flags"

  int32 :zero, "going to zero in a hurry"
  int32 :uno, description: "defaults to one", shortcut: "-u", default: 1

  def call
    self
  end
end

class TaskWithFloat64Flags < LuckyTask::Task
  summary "This is a task with float64 flags"

  float64 :zero, "going to zero in a hurry"
  float64 :uno, description: "defaults to one", shortcut: "-u", default: 1
  float64 :pi, description: "defaults to PI", shortcut: "-p", default: 3.14

  def call
    self
  end
end
```

* `int32` is implemented with flexibility to supply values in the form of `1000`, `1_000`, `+1000`, `-1000`
* `float64` is implemented with flexibility to supply values in the form of `1`, `1.0`, `-1.0`, `+1.0`, `1_000.0`, `10_000.000_001`