### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest
@@ -35,9 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.4.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.0.0
+          crystal: latest
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"

--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,11 @@ version: 0.1.1
 authors:
   - matthewmcgarvey <matthewmcgarvey14@gmail.com>
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.0.0


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
