### PR TITLE
Deprecate the name method in favor of task_name. 

### DIFF
--- a/spec/lucky_task/runner_spec.cr
+++ b/spec/lucky_task/runner_spec.cr
@@ -6,7 +6,7 @@ describe LuckyTask::Runner do
   it "adds tasks to the runner when task classes are created" do
     expected_task_names = ["another_task", "my.cool_task", "my.custom_name", "task_with_args", "task_with_required_format_args", "task_with_switch_flags", "task_with_int32_flags", "task_with_float64_flags", "task_with_positional_args", "task_with_fancy_output"]
 
-    task_names = LuckyTask::Runner.tasks.map(&.name)
+    task_names = LuckyTask::Runner.tasks.map(&.task_name)
     task_names.size.should eq(expected_task_names.size)
 
     expected_task_names.each do |expected_task_name|
@@ -15,7 +15,7 @@ describe LuckyTask::Runner do
   end
 
   it "lists all the available tasks" do
-    LuckyTask::Runner.tasks.map(&.name).each do |name|
+    LuckyTask::Runner.tasks.map(&.task_name).each do |name|
       LuckyTask::Runner.tasks_list.should contain(name)
     end
   end

--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -6,12 +6,12 @@ private abstract class ShouldNotBlowUpForAbstractClasses < LuckyTask::Task
 end
 
 describe LuckyTask::Task do
-  it "creates a name from the class name when inheriting" do
-    My::CoolTask.new.name.should eq "my.cool_task"
+  it "creates a task_name from the class name when inheriting" do
+    My::CoolTask.new.task_name.should eq "my.cool_task"
   end
 
-  it "uses a specified name over the auto generated name" do
-    Some::Other::Task.new.name.should eq "my.custom_name"
+  it "uses a specified task_name over the auto generated task_name" do
+    Some::Other::Task.new.task_name.should eq "my.custom_name"
   end
 
   it "creates summary text" do

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -8,7 +8,7 @@ end
 
 class Some::Other::Task < LuckyTask::Task
   summary "bar"
-  name "my.custom_name"
+  task_name "my.custom_name"
 
   def help_message
     "Custom help message"

--- a/src/lucky_task/runner.cr
+++ b/src/lucky_task/runner.cr
@@ -5,7 +5,7 @@ class LuckyTask::Runner
   extend LuckyTask::TextHelpers
 
   def self.tasks
-    @@tasks.sort_by!(&.name)
+    @@tasks.sort_by!(&.task_name)
   end
 
   def self.run(args = ARGV, io : IO = STDERR)
@@ -43,14 +43,14 @@ class LuckyTask::Runner
   end
 
   def self.find_task(task_name : String)
-    @@tasks.find { |task| task.name == task_name }
+    @@tasks.find { |task| task.task_name == task_name }
   end
 
   def self.tasks_list
     String.build do |list|
       tasks.each do |task|
-        list << ("  #{arrow} " + task.name).colorize(:green)
-        list << list_padding_for(task.name)
+        list << ("  #{arrow} " + task.task_name).colorize(:green)
+        list << list_padding_for(task.task_name)
         list << task.summary
         list << "\n"
       end
@@ -62,6 +62,6 @@ class LuckyTask::Runner
   end
 
   def self.longest_task_name
-    tasks.max_of(&.name.size)
+    tasks.max_of(&.task_name.size)
   end
 end

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -11,7 +11,12 @@ abstract class LuckyTask::Task
     {% end %}
     end
 
+    @[Deprecated("Use `task_name` instead.")]
     def name : String
+      task_name
+    end
+
+    def task_name : String
       "{{@type.name.gsub(/::/, ".").underscore}}"
     end
 
@@ -19,7 +24,7 @@ abstract class LuckyTask::Task
       <<-TEXT
       #{summary}
 
-      Run this task with 'lucky #{name}'
+      Run this task with 'lucky #{task_name}'
       TEXT
     end
 
@@ -46,22 +51,34 @@ abstract class LuckyTask::Task
     end
   end
 
-  # Sets a custom title for the task
+  # DEPRECATED: Use `task_name` instead
+  macro name(name_text)
+    @[Deprecated("Use `task_name` instead.")]
+    def name
+      task_name
+    end
+
+    def task_name : String
+      {{name_text}}
+    end
+  end
+
+  # Renames the task name for CLI use
   #
-  # By default the name is derived from the full module and class name.
-  # However if that name is not desired, a custom one can be set.
+  # By default the task name is derived from the full module and class name.
+  # However if that task name is not desired, a custom one can be set.
   #
   # ```
   # class Dev::Prime < LuckyTask::Task
   #   # Would be "dev.prime" by default, but we want to set it to "dev.setup":
-  #   name "dev.setup"
+  #   task_name "dev.setup"
   #   summary "Seed the development database with example data"
   #
   #   # other methods, etc.
   # end
   # ```
-  macro name(name_text)
-    def name
+  macro task_name(name_text)
+    def task_name : String
       {{name_text}}
     end
   end

--- a/src/lucky_task/task_not_found_error_message.cr
+++ b/src/lucky_task/task_not_found_error_message.cr
@@ -21,7 +21,7 @@ class LuckyTask::TaskNotFoundErrorMessage
   private def similar_task_name
     Levenshtein::Finder.find(
       @task_name,
-      LuckyTask::Runner.tasks.map(&.name),
+      LuckyTask::Runner.tasks.map(&.task_name),
       tolerance: 4
     )
   end


### PR DESCRIPTION
Fixes #10
Fixes #6 

I think it's fairly common for you to want to use `name` in your task. It's fairly generic, so this adds a new `task_name` that does the same thing. `name` will now be deprecated