### PR TITLE
Revert add finished macro

### DIFF
--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -5,11 +5,9 @@ abstract class LuckyTask::Task
     property option_parser : OptionParser = OptionParser.new
     property output : IO = STDOUT
 
-    macro finished
     {% if !@type.abstract? %}
       LuckyTask::Runner.tasks << self.new
     {% end %}
-    end
 
     @[Deprecated("Use `task_name` instead.")]
     def name : String


### PR DESCRIPTION
It seems to only affect Crystal 1.9.2, but I don't really have the time to investigate more in to why, so I'm just reverting this for now.

The issue is tasks are no longer found, so running `lucky -h` returns nothing, and trying to run any task just fails.

![image](https://github.com/luckyframework/lucky_task/assets/2391/7dc90702-ee98-4536-a816-907e69b11d33)
