### PR TITLE
Release v0.2.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky_task
-version: 0.1.1
+version: 0.2.0
 
 authors:
   - matthewmcgarvey <matthewmcgarvey14@gmail.com>

--- a/src/lucky_task.cr
+++ b/src/lucky_task.cr
@@ -3,5 +3,5 @@ require "./lucky_task/text_helpers"
 require "./lucky_task/*"
 
 module LuckyTask
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This is mainly some cleanup. The `name` method is now deprecated in favor of `task_name` to help avoid conflicts when you want to have a `name` arg in your custom tasks. 