### PR TITLE
Refactor internal API

### DIFF
--- a/spec/lucky_task/runner_spec.cr
+++ b/spec/lucky_task/runner_spec.cr
@@ -4,7 +4,7 @@ include HaveDefaultHelperMessageMatcher
 
 describe LuckyTask::Runner do
   it "adds tasks to the runner when task classes are created" do
-    expected_task_names = ["another_task", "my.cool_task", "my.custom_name", "task_with_args", "task_with_required_format_args", "task_with_switch_flags", "task_with_int32_flags", "task_with_float64_flags", "task_with_positional_args", "task_with_fancy_output"]
+    expected_task_names = ["another_task", "my.cool_task", "my.custom_name", "task_with_args", "task_with_required_format_args", "task_with_switch_flags", "task_with_int32_flags", "task_with_float64_flags", "task_with_positional_args", "task_with_fancy_output", "task_with_similar_method_names"]
 
     task_names = LuckyTask::Runner.tasks.map(&.task_name)
     task_names.size.should eq(expected_task_names.size)

--- a/spec/lucky_task/task_spec.cr
+++ b/spec/lucky_task/task_spec.cr
@@ -7,21 +7,21 @@ end
 
 describe LuckyTask::Task do
   it "creates a task_name from the class name when inheriting" do
-    My::CoolTask.new.task_name.should eq "my.cool_task"
+    My::CoolTask.task_name.should eq "my.cool_task"
   end
 
   it "uses a specified task_name over the auto generated task_name" do
-    Some::Other::Task.new.task_name.should eq "my.custom_name"
+    Some::Other::Task.task_name.should eq "my.custom_name"
   end
 
   it "creates summary text" do
-    My::CoolTask.new.summary.should eq "This task does something awesome"
+    My::CoolTask.task_summary.should eq "This task does something awesome"
   end
 
   it "has a default help message" do
-    message = My::CoolTask.new.help_message
+    message = My::CoolTask.task_help_message
     message.should contain "Run this task with 'lucky my.cool_task'"
-    message.should contain(My::CoolTask.new.summary)
+    message.should contain(My::CoolTask.task_summary)
   end
 
   describe "print_help_or_call" do
@@ -159,6 +159,18 @@ describe LuckyTask::Task do
 
       task.call
       task.output.to_s.should contain "Fancy output"
+    end
+  end
+
+  describe "methods that used to conflict" do
+    it "allows you to name the args whatever" do
+      task = TaskWithSimilarMethodNames.new
+      task.print_help_or_call(args: ["--name=name", "--task-name=task-name", "--summary=summary", "--task-summary=task-summary", "--help-message=help-message"]).as(TaskWithSimilarMethodNames)
+      task.name.should eq("name")
+      task.task_name.should eq("task-name")
+      task.summary.should eq("summary")
+      task.task_summary.should eq("task-summary")
+      task.help_message.should eq("help-message")
     end
   end
 end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -8,9 +8,9 @@ end
 
 class Some::Other::Task < LuckyTask::Task
   summary "bar"
-  task_name "my.custom_name"
+  name "my.custom_name"
 
-  def help_message
+  def self.help_message
     "Custom help message"
   end
 

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -8,7 +8,7 @@ end
 
 class Some::Other::Task < LuckyTask::Task
   summary "bar"
-  task_name "my.custom_name"
+  name "my.custom_name"
   help_message "Custom help message"
 
   def call
@@ -94,10 +94,20 @@ class TaskWithPositionalArgs < LuckyTask::Task
 end
 
 class TaskWithFancyOutput < LuckyTask::Task
-  summary "This is a task with some fancy output"
-
   def call
     output.puts "Fancy output".colorize.green
+    self
+  end
+end
+
+class TaskWithSimilarMethodNames < LuckyTask::Task
+  arg :name, "Using name"
+  arg :task_name, "Using task_name"
+  arg :summary, "Using summary"
+  arg :task_summary, "Using task_summary"
+  arg :help_message, "Using help_message"
+
+  def call
     self
   end
 end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -8,11 +8,8 @@ end
 
 class Some::Other::Task < LuckyTask::Task
   summary "bar"
-  name "my.custom_name"
-
-  def self.help_message
-    "Custom help message"
-  end
+  task_name "my.custom_name"
+  help_message "Custom help message"
 
   def call
   end

--- a/src/lucky_task/runner.cr
+++ b/src/lucky_task/runner.cr
@@ -1,14 +1,14 @@
 class LuckyTask::Runner
-  @@tasks = [] of LuckyTask::Task
+  @@tasks = [] of LuckyTask::Task.class
   class_property? exit_with_error_if_not_found : Bool = true
 
   extend LuckyTask::TextHelpers
 
-  def self.register_task(task : LuckyTask::Task) : Nil
+  def self.register_task(task : LuckyTask::Task.class) : Nil
     @@tasks.push(task)
   end
 
-  def self.tasks : Array(LuckyTask::Task)
+  def self.tasks : Array(LuckyTask::Task.class)
     @@tasks.sort_by!(&.task_name)
   end
 
@@ -21,7 +21,7 @@ class LuckyTask::Runner
       io.puts <<-HELP_TEXT
       Missing a task name
 
-      To see a list of available tasks, run #{"lucky --help".colorize(:green)}
+      To see a list of available tasks, run #{"lucky tasks".colorize(:green)}
       HELP_TEXT
     else
       if task = find_task(task_name)
@@ -47,7 +47,10 @@ class LuckyTask::Runner
   end
 
   def self.find_task(task_name : String) : LuckyTask::Task?
-    @@tasks.find { |task| task.task_name == task_name }
+    found_task = @@tasks.find { |task| task.task_name == task_name }
+    if found_task
+      found_task.new
+    end
   end
 
   def self.tasks_list : String

--- a/src/lucky_task/runner.cr
+++ b/src/lucky_task/runner.cr
@@ -58,7 +58,7 @@ class LuckyTask::Runner
       tasks.each do |task|
         list << ("  #{arrow} " + task.task_name).colorize(:green)
         list << list_padding_for(task.task_name)
-        list << task.summary
+        list << task.task_summary
         list << "\n"
       end
     end

--- a/src/lucky_task/task.cr
+++ b/src/lucky_task/task.cr
@@ -17,16 +17,16 @@ abstract class LuckyTask::Task
 
     # By default, task summaries are optional.
     # Use the `summary` macro to define a custom summary
-    def self.summary : String
+    def self.task_summary : String
       ""
     end
 
     # The help text to be displayed when a help flag
     # is passed in (e.g. -h, --help)
     # Use the `help_message`
-    def self.help_message : String
+    def self.task_help_message : String
       <<-TEXT.strip
-      #{summary}
+      #{task_summary}
 
       Run this task with 'lucky #{task_name}'
       TEXT
@@ -34,7 +34,7 @@ abstract class LuckyTask::Task
 
     def print_help_or_call(args : Array(String))
       if wants_help_message?(args)
-        output.puts self.class.help_message
+        output.puts self.class.task_help_message
       else
         \{% for opt in @type.constant(:PARSER_OPTS) %}
         set_opt_for_\{{ opt.id }}(args)
@@ -54,7 +54,7 @@ abstract class LuckyTask::Task
   # This is used in the help_text when a help flag is passed
   # to the task through the CLI
   macro summary(summary_text)
-    def self.summary : String
+    def self.task_summary : String
       {{summary_text}}
     end
   end
@@ -73,7 +73,7 @@ abstract class LuckyTask::Task
   #   # other methods, etc.
   # end
   # ```
-  macro task_name(name_text)
+  macro name(name_text)
     def self.task_name : String
       {{name_text}}
     end
@@ -90,7 +90,7 @@ abstract class LuckyTask::Task
   # end
   # ```
   macro help_message(help_text)
-    def self.help_message : String
+    def self.task_help_message : String
       {{help_text}}
     end
   end


### PR DESCRIPTION
Fixes #23

This is a pretty big refactor and breaking change that moves the internal methods from instance methods to class methods. 


This changes up quite a few things.
* Reverts the `task_name` macro back to `name` like it was before, but keeps the generated method as `task_name`
* Changes the generated summary name to `task_summary`
* Summary is now optional
* Changes the help_message to `task_help_message`
* Moves all of these from instance methods to class methods

Because Crystal treats macros like class methods, and arguments on macros are always optional, you can't really have a class method with no args be the same name as a macro. So to avoid a compilation error, the methods are named different from their macro counterparts.


### Old interface
```crystal
class My::Task < LuckyTask::Task
  name "new.name"
  summary "Here is my description"

  def help_message
    "my custom help message"
  end

  def call
    # do stuff
  end
end

task = My::Task.new
task.name #=> "new.name"
task.summary #=> "Here is my description"
task.help_message #=> "my custom help message"
task.print_help_or_call(["-v"])
```

### New Interface
```crystal
class My::Task < LuckyTask::Task
  name "new.name"
  summary "Here is my description"
  help_message "my custom help message"

  def call
    # do stuff
  end
end

My::Task.task_name #=> "new.name"
My::Task.task_summary #=> "Here is my description"
My::Task.task_help_message #=> "my custom help message"
My::Task.new.print_help_or_call(["-v"])
```