### PR TITLE
Release v0.3.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky_task
-version: 0.2.0
+version: 0.3.0
 
 authors:
   - matthewmcgarvey <matthewmcgarvey14@gmail.com>

--- a/src/lucky_task.cr
+++ b/src/lucky_task.cr
@@ -3,5 +3,5 @@ require "./lucky_task/text_helpers"
 require "./lucky_task/*"
 
 module LuckyTask
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This release is a major refactor that changes a bit of the internal API. It now has better control to avoid naming conflict when one of your arg methods might match up with the API itself.

### Upgrading

* move `help_message` instance method to a macro
* References to `summary` used in your `help_message` should now call `task_summary`
* If you upgraded to v0.2.0 and replaced `name` with `task_name`, you can revert that back to `name`

Before:
```crystal
class Task < LuckyTask::Task
  summary "Does thing"
  def help_message
    "#{summary} and more"
  end

  def call
   # do stuff
  end
end
```

After
```crystal
class Task < LuckyTask::Task
  summary "Does thing"
  help_message "#{task_summary} and more"

  def call
   # do stuff
  end
end
```

If you didn't override `help_message` or `name`, then you have nothing to change.